### PR TITLE
specify lzstring dev version

### DIFF
--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -56,6 +56,9 @@ jobs:
       )
     name: revdepcheck ↩️
     uses: insightsengineering/r.pkg.template/.github/workflows/revdepcheck.yaml@main
+    with:
+      lookup-refs: |
+        parmsam/lzstring-r
   rhub:
     if: >
       github.event_name == 'schedule' || (
@@ -64,3 +67,6 @@ jobs:
       )
     name: R-hub 🌐
     uses: insightsengineering/r.pkg.template/.github/workflows/rhub.yaml@main
+    with:
+      lookup-refs: |
+        parmsam/lzstring-r

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -56,9 +56,6 @@ jobs:
       )
     name: revdepcheck ↩️
     uses: insightsengineering/r.pkg.template/.github/workflows/revdepcheck.yaml@main
-    with:
-      lookup-refs: |
-        parmsam/lzstring-r
   rhub:
     if: >
       github.event_name == 'schedule' || (
@@ -67,6 +64,3 @@ jobs:
       )
     name: R-hub 🌐
     uses: insightsengineering/r.pkg.template/.github/workflows/rhub.yaml@main
-    with:
-      lookup-refs: |
-        parmsam/lzstring-r

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,6 +23,8 @@ Suggests:
     pkgdown (>= 2.0.0),
     testthat (>= 3.1.5),
     withr (>= 2.4.3)
+Remotes:
+    lzstring=parmsam/lzstring-r
 Config/Needs/verdepcheck: tidyverse/glue, jeroen/jsonlite,
     lzstring=parmsam/lzstring-r, r-lib/roxygen2, tidyverse/stringr,
     r-lib/pkgdown, r-lib/testthat, r-lib/withr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ Depends:
 Imports:
     glue,
     jsonlite (>= 1.8.6),
-    lzstring,
+    lzstring (>= 0.1.3),
     roxygen2 (>= 7.2.0),
     stringr (>= 0.4)
 Suggests:

--- a/roxy.shinylive.Rproj
+++ b/roxy.shinylive.Rproj
@@ -5,7 +5,12 @@ SaveWorkspace: No
 AlwaysSaveHistory: Default
 
 EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
 Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
 
 AutoAppendNewline: Yes
 StripTrailingWhitespace: Yes


### PR DESCRIPTION
This potentially unblocks r-hub checks for packages that use roxy.shinylive, like teal.modules.general

https://github.com/insightsengineering/teal.modules.general/actions/runs/11162904017/job/31028602918#step:8:83