### PR TITLE
use released version of lzstring

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,8 +23,6 @@ Suggests:
     pkgdown (>= 2.0.0),
     testthat (>= 3.1.5),
     withr (>= 2.4.3)
-Remotes:
-    lzstring=parmsam/lzstring-r
 Config/Needs/verdepcheck: tidyverse/glue, jeroen/jsonlite,
     lzstring=parmsam/lzstring-r, r-lib/roxygen2, tidyverse/stringr,
     r-lib/pkgdown, r-lib/testthat, r-lib/withr


### PR DESCRIPTION
- `lzstring` got released so there is no need for a Remotes field
- small tests enhancements
- add test about respecting the order