### PR TITLE
Make sure that the examples take up the full page width

### DIFF
--- a/R/tag_examplesShinylive.R
+++ b/R/tag_examplesShinylive.R
@@ -213,7 +213,8 @@ format.rd_section_examplesShinylive <- function(x, ...) {
     paste0(
       "  \\item{example-", seq_along(x$value), "}{\n",
       "    \\href{", x$value, "}{Open in Shinylive}\n",
-      "    \\if{html}{\\out{<iframe class=\"iframe_shinylive\" src=\"", x$value, "\" ", iframe_style, "></iframe><div style='height: ", app_height, ";'></div>}}\n", # nolint: line_length_linter.
+      "    \\if{html}{\\out{<iframe class=\"iframe_shinylive\" src=\"", x$value, "\" ", iframe_style, "></iframe>}}\n", # nolint: line_length_linter.
+      "    \\if{html}{\\out{<div style='height: ", app_height, "; display: block;'>&nbsp;</div>}}\n",
       "  }\n",
       collapse = ""
     ),

--- a/R/tag_examplesShinylive.R
+++ b/R/tag_examplesShinylive.R
@@ -189,17 +189,20 @@ roxy_tag_rd.roxy_tag_examplesShinylive <- function(x, base_path, env) {
 #' @exportS3Method format rd_section_examplesShinylive
 format.rd_section_examplesShinylive <- function(x, ...) {
   app_height <- "800px"
+  app_max_width <- "1400px"
   iframe_style <- paste0(
     "style=\"",
     paste(
       paste0("height: ", app_height),
       "width: 100vw",
+      paste0("max-width: ", app_max_width),
       "border: 1px solid rgba(0,0,0,0.175)",
       "border-radius: .375rem",
       "position: absolute",
-      "z-index: 1",
-      "left: 0",
+      "left: 50\\%",
       "margin-top: 30px",
+      "transform: translateX(-50\\%)",
+      "z-index: 1",
       sep = "; "
     ),
     "\""

--- a/R/tag_examplesShinylive.R
+++ b/R/tag_examplesShinylive.R
@@ -192,7 +192,7 @@ format.rd_section_examplesShinylive <- function(x, ...) {
   iframe_style <- paste0(
     "style=\"",
     paste(
-      "height: ", app_height,
+      paste0("height: ", app_height),
       "width: 100vw",
       "border: 1px solid rgba(0,0,0,0.175)",
       "border-radius: .375rem",

--- a/R/tag_examplesShinylive.R
+++ b/R/tag_examplesShinylive.R
@@ -214,7 +214,8 @@ format.rd_section_examplesShinylive <- function(x, ...) {
       "  \\item{example-", seq_along(x$value), "}{\n",
       "    \\href{", x$value, "}{Open in Shinylive}\n",
       "    \\if{html}{\\out{<iframe class=\"iframe_shinylive\" src=\"", x$value, "\" ", iframe_style, "></iframe>}}\n", # nolint: line_length_linter.
-      "    \\if{html}{\\out{<div style='height: ", app_height, "; display: block;'>&nbsp;</div>}}\n",
+      # empty a tag because Tidy complains about empty spans.
+      "    \\if{html}{\\out{<a style='height: ", app_height, "; display: block;'></a>}}\n",
       "  }\n",
       collapse = ""
     ),

--- a/R/tag_examplesShinylive.R
+++ b/R/tag_examplesShinylive.R
@@ -204,18 +204,12 @@ format.rd_section_examplesShinylive <- function(x, ...) {
     ),
     "\""
   )
-  # If in pkgdown website - increase the width
-  jscode <- "
-$(function() {
-  var if_pkgdown = [...document.scripts].filter(x => x.src.includes(\"pkgdown.js\")).length > 0;
-});"
   paste0(
     "\\section{Examples in Shinylive}{\n",
     "\\describe{\n",
     paste0(
       "  \\item{example-", seq_along(x$value), "}{\n",
       "    \\href{", x$value, "}{Open in Shinylive}\n",
-      "    \\if{html}{\\out{<script type=\"text/javascript\">", gsub("\n", "", jscode), "</script>}}\n",
       "    \\if{html}{\\out{<iframe class=\"iframe_shinylive\" src=\"", x$value, "\" ", iframe_style, "></iframe><div style='height: ", app_height, ";'></div>}}\n", # nolint: line_length_linter.
       "  }\n",
       collapse = ""

--- a/R/tag_examplesShinylive.R
+++ b/R/tag_examplesShinylive.R
@@ -188,10 +188,11 @@ roxy_tag_rd.roxy_tag_examplesShinylive <- function(x, base_path, env) {
 #' @noRd
 #' @exportS3Method format rd_section_examplesShinylive
 format.rd_section_examplesShinylive <- function(x, ...) {
+  app_height <- "800px"
   iframe_style <- paste0(
     "style=\"",
     paste(
-      "height: 800px",
+      "height: ", app_height,
       "width: 100vw",
       "border: 1px solid rgba(0,0,0,0.175)",
       "border-radius: .375rem",
@@ -215,7 +216,7 @@ $(function() {
       "  \\item{example-", seq_along(x$value), "}{\n",
       "    \\href{", x$value, "}{Open in Shinylive}\n",
       "    \\if{html}{\\out{<script type=\"text/javascript\">", gsub("\n", "", jscode), "</script>}}\n",
-      "    \\if{html}{\\out{<iframe class=\"iframe_shinylive\" src=\"", x$value, "\" ", iframe_style, "></iframe><div style='height: 800px;'></div>}}\n", # nolint: line_length_linter.
+      "    \\if{html}{\\out{<iframe class=\"iframe_shinylive\" src=\"", x$value, "\" ", iframe_style, "></iframe><div style='height: ", app_height, ";'></div>}}\n", # nolint: line_length_linter.
       "  }\n",
       collapse = ""
     ),

--- a/R/tag_examplesShinylive.R
+++ b/R/tag_examplesShinylive.R
@@ -192,11 +192,13 @@ format.rd_section_examplesShinylive <- function(x, ...) {
     "style=\"",
     paste(
       "height: 800px",
-      "width: 100\\%",
+      "width: 100vw",
       "border: 1px solid rgba(0,0,0,0.175)",
       "border-radius: .375rem",
-      "position: relative",
+      "position: absolute",
       "z-index: 1",
+      "left: 0",
+      "margin-top: 30px",
       sep = "; "
     ),
     "\""
@@ -205,9 +207,6 @@ format.rd_section_examplesShinylive <- function(x, ...) {
   jscode <- "
 $(function() {
   var if_pkgdown = [...document.scripts].filter(x => x.src.includes(\"pkgdown.js\")).length > 0;
-  if (if_pkgdown) {
-    $(\"iframe.iframe_shinylive\").css(\"width\", \"150\\%\");
-  }
 });"
   paste0(
     "\\section{Examples in Shinylive}{\n",
@@ -216,7 +215,7 @@ $(function() {
       "  \\item{example-", seq_along(x$value), "}{\n",
       "    \\href{", x$value, "}{Open in Shinylive}\n",
       "    \\if{html}{\\out{<script type=\"text/javascript\">", gsub("\n", "", jscode), "</script>}}\n",
-      "    \\if{html}{\\out{<iframe class=\"iframe_shinylive\" src=\"", x$value, "\" ", iframe_style, "></iframe>}}\n", # nolint: line_length_linter.
+      "    \\if{html}{\\out{<iframe class=\"iframe_shinylive\" src=\"", x$value, "\" ", iframe_style, "></iframe><div style='height: 800px;'></div>}}\n", # nolint: line_length_linter.
       "  }\n",
       collapse = ""
     ),


### PR DESCRIPTION
Closes #5 
Here is a screenshot of the reference page with multiple examples.

![screencapture-file-Users-vedha-insightsengineering-teal-modules-general-docs-reference-tm-g-response-html-2024-11-04-20_19_17](https://github.com/user-attachments/assets/3deebd9c-2936-407d-a7a1-d5e58c0895b8)
